### PR TITLE
add a script interpreter, use functions, toggle virtual router

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,11 @@ vm_tools()
   apk add sfdisk
   apk add e2fsprogs-extra
   apk add util-linux
+}
 
+
+vm_services()
+{
   rc-update add udev boot
   rc-update add iptables boot
   rc-update add open-vm-tools boot
@@ -58,6 +62,7 @@ main()
   
   vm_tools
   deploy_files
+  vm_services
   vrouter_or_not
 }
 

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,8 @@ vm_tools()
 
 deploy_files()
 {
-  rsync -ar etc/* /
-  rsync -ar usr/* /
+  rsync -ar etc /
+  rsync -ar usr /
 }
 
 

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ vm_tools()
 {
   apk add rsync
   apk add udev
+  apk add iptables
   apk add open-vm-tools
   apk add sfdisk
   apk add e2fsprogs-extra

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ vrouter_addons()
 vm_tools()
 {
   apk add rsync
+  apk add udev
   apk add open-vm-tools
   apk add sfdisk
   apk add e2fsprogs-extra

--- a/install.sh
+++ b/install.sh
@@ -1,20 +1,63 @@
-apk update
-apk add open-vm-tools
-apk add quagga
+#!/bin/sh -e
 
-apk add udev
-apk add sfdisk
-apk add e2fsprogs-extra
-apk add util-linux
 
-apk cache clean
+vrouter_addons()
+{
+  apk add quagga
+  rc-update add keepalived boot
+}
 
-rc-update add keepalived boot
-rc-update add udev boot
-rc-update add iptables boot
-rc-update add open-vm-tools boot
-rc-update add acpid boot
 
-rc-update add one-context boot
+vm_tools()
+{
+  apk add rsync
+  apk add open-vm-tools
+  apk add sfdisk
+  apk add e2fsprogs-extra
+  apk add util-linux
 
-echo '' > /etc/resolv.conf
+  rc-update add udev boot
+  rc-update add iptables boot
+  rc-update add open-vm-tools boot
+  rc-update add acpid boot
+  rc-update add one-context boot
+}
+
+
+deploy_files()
+{
+  rsync -ar etc/* /
+  rsync -ar usr/* /
+}
+
+
+vrouter_or_not()
+{
+# if VROUTER is set to no the ONE virtual router parts are skipped.
+  if [ "x${VROUTER}" = "xno" ]; then 
+    # delete vrouter files
+    rm /etc/one-context.d/02-keepalived /etc/sysctl.d/01-one.conf
+    else
+    vrouter_addons
+  fi
+}
+
+
+cleanup()
+{
+  echo '' > /etc/resolv.conf
+  apk cache clean
+}
+
+
+main()
+{
+  # start, just fetch fresh info
+  apk update
+  
+  vm_tools
+  deploy_files
+  vrouter_or_not
+}
+
+main


### PR DESCRIPTION
- adds a script interpreter so it'll be runnable.
- puts all steps in functions
- exit on errors
- have a switch that changes virtual router support on or off (allows to install non-keepalived version)
- deploys the files to /etc and /usr

this means one can now just run chmod 700 install.sh && ./install.sh and it'll be done
